### PR TITLE
Remove publisher and adjust homepage to fix Java publishing

### DIFF
--- a/provider/cmd/pulumi-resource-scm/schema.json
+++ b/provider/cmd/pulumi-resource-scm/schema.json
@@ -8,12 +8,11 @@
         "paloaltonetworks",
         "category/network"
     ],
-    "homepage": "https://github.com/pulumi/pulumi-scm",
+    "homepage": "https://pulumi.com",
     "license": "Apache-2.0",
     "attribution": "This Pulumi package is based on the [`scm` Terraform Provider](https://github.com/PaloAltoNetworks/terraform-provider-scm).",
     "repository": "https://github.com/pulumi/pulumi-scm",
     "logoUrl": "https://raw.githubusercontent.com/pulumi/pulumi-scm/main/docs/logo.png",
-    "publisher": "pulumi",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"
     },

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -51,11 +51,6 @@ func Provider() tfbridge.ProviderInfo {
 		// DisplayName is a way to be able to change the casing of the provider
 		// name when being displayed on the Pulumi registry
 		DisplayName: "Strata Cloud Manager",
-		// The default publisher for all packages is Pulumi.
-		// Change this to your personal name (or a company name) that you
-		// would like to be shown in the Pulumi Registry if this package is published
-		// there.
-		Publisher: "pulumi",
 		// LogoURL is optional but useful to help identify your package in the Pulumi Registry
 		// if this package is published there.
 		//
@@ -73,7 +68,7 @@ func Provider() tfbridge.ProviderInfo {
 			"category/network",
 		},
 		License:    "Apache-2.0",
-		Homepage:   "https://github.com/pulumi/pulumi-scm",
+		Homepage:   "https://pulumi.com",
 		Repository: "https://github.com/pulumi/pulumi-scm",
 		// The GitHub Org for the provider - defaults to `terraform-providers`. Note that this
 		// should match the TF provider module's require directive, not any replace directives.

--- a/sdk/dotnet/Pulumi.Scm.csproj
+++ b/sdk/dotnet/Pulumi.Scm.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>pulumi</Authors>
-    <Company>pulumi</Company>
+    <Authors>Pulumi Corp.</Authors>
+    <Company>Pulumi Corp.</Company>
     <Description>A Pulumi package for managing resources on Strata Cloud Manager.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/pulumi/pulumi-scm</PackageProjectUrl>
+    <PackageProjectUrl>https://pulumi.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-scm</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
     <Version>0.0.0-alpha.0+dev</Version>

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -89,8 +89,8 @@ publishing {
             artifact javadocJar
 
             pom {
-                inceptionYear = ""
-                name = ""
+                inceptionYear = "2022"
+                name = "pulumi-scm"
                 packaging = "jar"
                 description = "A Pulumi package for managing resources on Strata Cloud Manager."
 
@@ -111,9 +111,9 @@ publishing {
 
                 developers {
                     developer {
-                        id = ""
-                        name = ""
-                        email = ""
+                        id = "pulumi"
+                        name = "Pulumi"
+                        email = "support@pulumi.com"
                     }
                 }
             }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -8,7 +8,7 @@
         "paloaltonetworks",
         "category/network"
     ],
-    "homepage": "https://github.com/pulumi/pulumi-scm",
+    "homepage": "https://pulumi.com",
     "repository": "https://github.com/pulumi/pulumi-scm",
     "license": "Apache-2.0",
     "scripts": {

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -9,7 +9,7 @@
   [project.license]
     text = "Apache-2.0"
   [project.urls]
-    Homepage = "https://github.com/pulumi/pulumi-scm"
+    Homepage = "https://pulumi.com"
     Repository = "https://github.com/pulumi/pulumi-scm"
 
 [build-system]


### PR DESCRIPTION
Same as https://github.com/pulumi/pulumi-dbtcloud/pull/23

Right now, the Java publishing step fails because POM values aren't set correctly. We need to set the publisher and/or home page to expected values. This PR removes the non-canonical publisher (could have been `Pulumi`) and set the canonical homepage.