### PR TITLE
Update SCM docs for docs search

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Strata Cloud Manager
+title: Strata Cloud Manager (Palo Alto SCM)
 meta_desc: Provides an overview of the Strata Cloud Manager Provider for Pulumi.
 layout: overview
 ---


### PR DESCRIPTION
Searching for Palo Alto SCM does not help users find the right docs, this will fix it.

Fixes https://github.com/pulumi/docs/issues/12748